### PR TITLE
Lookup SHA with image tag and support non-default ref

### DIFF
--- a/.github/workflows/build-push-multi-arch.yml
+++ b/.github/workflows/build-push-multi-arch.yml
@@ -37,6 +37,10 @@ on:
         description: 'Path where the artifact should be downloaded to'
         required: false
         type: string
+      checkout_ref:
+        description: 'The reference for the repository checkout'
+        required: false
+        type: string
     secrets:
       token:
         description: 'The GitHub token passed from the caller workflow'
@@ -53,7 +57,14 @@ jobs:
     outputs:
       image_hash: ${{ steps.build-push.outputs.sha }}
     steps:
+      - name: Checkout repository with ref
+        if: inputs.checkout_ref != ''
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.checkout_ref }}
+
       - name: Checkout repository
+        if: inputs.checkout_ref == ''
         uses: actions/checkout@v3
 
       - name: Download artifact

--- a/.github/workflows/build-push-multi-arch.yml
+++ b/.github/workflows/build-push-multi-arch.yml
@@ -93,6 +93,6 @@ jobs:
             --platform=${{ inputs.platforms }} ${{ inputs.build_flags }} \
             --push --provenance=false --sbom=false ${IMAGES[@]} \
             ${{ inputs.build_context_path }}
-          SHA=$(docker buildx imagetools inspect ${IMAGE} | grep Digest)
+          SHA=$(docker buildx imagetools inspect ${IMAGE}:${TAG} | grep Digest)
           echo "sha=${SHA##*sha256:}" >> $GITHUB_OUTPUT
         shell: bash

--- a/.github/workflows/write-file.yml
+++ b/.github/workflows/write-file.yml
@@ -28,8 +28,7 @@ jobs:
         run: |
           git config user.name github-actions[bot]
           git config user.email github-actions[bot]@users.noreply.github.com
-          git reset --hard HEAD && git fetch origin ${{ inputs.branch }} || exit 1
-          git checkout ${{ inputs.branch }} && git rebase origin/main || exit 1
+          git reset --hard HEAD && git fetch origin ${{ inputs.branch }} && git checkout ${{ inputs.branch }} || exit 1
           echo ${{ inputs.content }} > ${{ inputs.filepath }}
           git add ${{ inputs.filepath }}
           git commit -m "Write file: ${{ inputs.filepath }}" && git push -f


### PR DESCRIPTION
<!-- AICA Pull Request Template: 10 easy steps for a successful PR!
1. Give the PR a relevant and descriptive title
2. Link the PR to the parent issue, which should already describe and motivate the PR
3. Explain how the PR addresses the parent issue
6. Add any supporting resources (screenshots, test results, etc)
7. Help the reviewer by suggestion the method and estimated time to review
8. If applicable, make a checklist of tasks that should be completed before merging
9. If applicable, mention related issues (blocked by / blocks)
10. Post creation actions: tag reviewers and link the PR to its parent issue under the Development section
-->

## Description

<!-- Required: link the parent issue -->
- #3 

<!-- Required: explain how the PR addresses the parent issue -->
We arrived at the last line of the workflow and I still found another bug. After the `for` loop with the multiple image tags, the variable `IMAGE` was left without a tag. If you now build an image with a tag different from `latest`, this `docker inspect` command will fail because no such image could be found. I'm hence using the loop variable of the `for` loop as a tag that exists. Luckily, this variable exists even after the loop is done.

Additionally, a workflow might need to checkout a different reference than the reference from which the workflow was triggered from. For example, a scheduled workflow is always triggered from main, but it might to checkout develop branch. Similarly, it is too restrictive for the `write-file` workflow to rebase the target branch on `origin/main` because it might have a different base.

<!-- Optional: add additional resources (links, screenshots, test results, etc)
## Supporting information
-->

## Review guidelines

<!-- Required: estimate how long a review should take -->
Estimated Time of Review: 5 minutes

<!-- Optional: provide more suggestions such as "Review by commit", "Read this documentation first", etc -->

<!-- Optional: define a task list that should be completed before merging
## Checklist before merging:
- [x] Task 1
- [ ] Task 2
-->

<!-- Optional: link related issues
## Related issues
### Blocked by:
- #0

### Blocks:
- #0
-->