### PR TITLE
feat(gha): make write-file more generic, add a way to extract files from docker images

### DIFF
--- a/.github/actions/docker-extract/action.yml
+++ b/.github/actions/docker-extract/action.yml
@@ -1,0 +1,26 @@
+name: Run a docker image and extract a file
+
+inputs:
+  image:
+    description: "The image to run"
+    required: true
+    type: string
+  source:
+    description: "The file within the image to extract"
+    required: true
+    type: string
+  destination:
+    description: "The path to extract the file to"
+    required: true
+    type: string
+
+runs:
+  using: composite
+  steps:
+    - name: Start a container, copy a file and delete it
+      run: |
+        NAME="copying$(uuidgen)"
+        docker create -ti --name "$NAME" ${{ inputs.image }} bash
+        docker cp "$NAME":"${{ inputs.source }}" "${{ inputs.destination }}"
+        docker rm -f "$NAME"
+      shell: bash

--- a/.github/actions/write-file/action.yml
+++ b/.github/actions/write-file/action.yml
@@ -50,6 +50,11 @@ runs:
         git config --global user.name github-actions[bot]
         git config --global user.email github-actions[bot]@users.noreply.github.com
 
+        if [ -n "${{ inputs.filepath }}" && -n "${{ inputs.file_source }}" ]; then
+          echo "Cannot specify both filepath and file_source"
+          exit 1
+        fi
+
         DEST="${{ inputs.checkout_path }}/${{ inputs.filepath }}"
         mkdir -p "$(dirname \"$DEST\")"
         if [ -n "${{ inputs.file_source }}" ]; then

--- a/.github/actions/write-file/action.yml
+++ b/.github/actions/write-file/action.yml
@@ -1,6 +1,10 @@
 name: Write File
 
 inputs:
+  repository:
+    description: "The repository to commit to"
+    required: false
+    type: string
   content:
     description: "The content to be written to file"
     required: true
@@ -13,19 +17,47 @@ inputs:
     description: "The name of the branch to commit to"
     required: true
     type: string
+  input_is_a_file:
+    description: "Whether the input is a file (default: false)"
+    required: false
+    default: false
+    type: boolean
+  token:
+    description: "The token to use for authentication"
+    type: string
+  message:
+    description: "The commit message"
+    required: false
+    type: string
 
 runs:
   using: composite
   steps:
     - name: Checkout repository
       uses: actions/checkout@v3
+      with:
+        repository: ${{ inputs.repository }}
+        ref: ${{ inputs.branch }}
+        path: ${{ github.action_path }}/repo
+        token: ${{ inputs.token }}
 
     - name: Write file
       run: |
         git config user.name github-actions[bot]
         git config user.email github-actions[bot]@users.noreply.github.com
-        git reset --hard HEAD && git fetch origin ${{ inputs.branch }} && git checkout ${{ inputs.branch }} || exit 1
-        echo ${{ inputs.content }} > ${{ inputs.filepath }}
+
+        mkdir -p $(dirname ${{ inputs.filepath }})
+        if [ "${{ inputs.input_is_a_file }}" = true ]; then
+          cp ${{ inputs.content }} ${{ inputs.filepath }}
+        else
+          echo "${{ inputs.content }}" > ${{ inputs.filepath }}
+        fi
+
         git add ${{ inputs.filepath }}
-        git commit -m "Write file: ${{ inputs.filepath }}" && git push -f
+        DEFAULT_MSG="automatically update ${{ inputs.filepath }}"
+        if [ -n "${{ inputs.message }}" ]; then
+          DEFAULT_MSG="${{ inputs.message }}"
+        fi
+        git commit -m "ci: $DEFAULT_MSG"
+        git push -f
       shell: bash

--- a/.github/actions/write-file/action.yml
+++ b/.github/actions/write-file/action.yml
@@ -47,8 +47,8 @@ runs:
 
     - name: Write file
       run: |
-        git config user.name github-actions[bot]
-        git config user.email github-actions[bot]@users.noreply.github.com
+        git config --global user.name github-actions[bot]
+        git config --global user.email github-actions[bot]@users.noreply.github.com
 
         DEST="${{ inputs.checkout_path }}/${{ inputs.filepath }}"
         mkdir -p "$(dirname \"$DEST\")"

--- a/.github/actions/write-file/action.yml
+++ b/.github/actions/write-file/action.yml
@@ -28,6 +28,11 @@ inputs:
     description: "The commit message"
     required: false
     type: string
+  checkout_path:
+    description: "The path to checkout the repository to"
+    required: false
+    default: repo
+    type: string
 
 runs:
   using: composite
@@ -37,7 +42,7 @@ runs:
       with:
         repository: ${{ inputs.repository }}
         ref: ${{ inputs.branch }}
-        path: ${{ github.action_path }}/repo
+        path: ${{ inputs.checkout_path }}
         token: ${{ inputs.token }}
 
     - name: Write file
@@ -45,17 +50,19 @@ runs:
         git config user.name github-actions[bot]
         git config user.email github-actions[bot]@users.noreply.github.com
 
-        mkdir -p $(dirname ${{ inputs.filepath }})
+        DEST="${{ inputs.checkout_path }}/${{ inputs.filepath }}"
+        mkdir -p "$(dirname \"$DEST\")"
         if [ -n "${{ inputs.file_source }}" ]; then
-          cp ${{ inputs.file_source }} ${{ inputs.filepath }}
+          cp ${{ inputs.file_source }} "$DEST"
         elif [ -n "${{ inputs.content }}" ]; then
-          echo "${{ inputs.content }}" > ${{ inputs.filepath }}
+          echo "${{ inputs.content }}" > "$DEST"
         else
           echo "No content or file_source specified"
           exit 1
         fi
 
-        git add ${{ inputs.filepath }}
+        cd "${{ inputs.checkout_path }}"
+        git add "${{ inputs.filepath }}"
         DEFAULT_MSG="automatically update ${{ inputs.filepath }}"
         if [ -n "${{ inputs.message }}" ]; then
           DEFAULT_MSG="${{ inputs.message }}"

--- a/.github/actions/write-file/action.yml
+++ b/.github/actions/write-file/action.yml
@@ -6,8 +6,8 @@ inputs:
     required: false
     type: string
   content:
-    description: "The content to be written to file"
-    required: true
+    description: "The content to be written to file (incompatible with `file_source`)"
+    required: false
     type: string
   filepath:
     description: "The path of the file"
@@ -17,11 +17,10 @@ inputs:
     description: "The name of the branch to commit to"
     required: true
     type: string
-  input_is_a_file:
-    description: "Whether the input is a file (default: false)"
+  file_source:
+    description: "The file to be copied (incompatible with `content`)"
     required: false
-    default: false
-    type: boolean
+    type: string
   token:
     description: "The token to use for authentication"
     type: string
@@ -47,10 +46,13 @@ runs:
         git config user.email github-actions[bot]@users.noreply.github.com
 
         mkdir -p $(dirname ${{ inputs.filepath }})
-        if [ "${{ inputs.input_is_a_file }}" = true ]; then
-          cp ${{ inputs.content }} ${{ inputs.filepath }}
-        else
+        if [ -n "${{ inputs.file_source }}" ]; then
+          cp ${{ inputs.file_source }} ${{ inputs.filepath }}
+        elif [ -n "${{ inputs.content }}" ]; then
           echo "${{ inputs.content }}" > ${{ inputs.filepath }}
+        else
+          echo "No content or file_source specified"
+          exit 1
         fi
 
         git add ${{ inputs.filepath }}


### PR DESCRIPTION
## Description

This PR reworks one action and add a new one, this is to support development in `backend-api`.

 * `write-file`: is much more generic, allows to pull from different repo than the current one, customize commit message or checkout path and even copy a file from the disk instead of passing the content as argument
 * `docker-extract`: will create a docker container from an image (but not run it) and copy a file from within, this is a very convenient and efficient way to extract files from images (especially scratch) without having to mount folders, ssh in, etc

## Review guidelines

Estimated Time of Review: 5 minutes

## Related issues
### Blocks:

`backend-api` PR.