### PR TITLE
fix(gha): auto-releaser builds Docker tag with the wrong name on the wrong branch

### DIFF
--- a/.github/actions/docker-tag-from-git/action.yml
+++ b/.github/actions/docker-tag-from-git/action.yml
@@ -11,14 +11,20 @@ runs:
     - name: Pick a tag
       id: pick
       run: |
+        # develop-<run_number> if it's develop
+        # latest if it's main
+        # <tag> if it's a tag
+        # <branch> if it's a branch (and replace / with -)
         GITHUB_REFER="${{ github.ref }}"
         BRANCH="${{ github.ref_name }}"
         if [[ "${BRANCH}" == "develop" ]]; then
           TAG="develop-${{ github.run_number }}"
         elif [[ "${BRANCH}" == "main" ]]; then
           TAG=latest
+        elif [[ "${GITHUB_REFER}" == "refs/tags/"* ]]; then
+          TAG="${GITHUB_REFER#refs/tags/}"
         else
-          TAG="${GITHUB_REFER#refs/*/}"
+          TAG="${BRANCH//\//-}"
         fi
         echo "Tag: ${TAG}"
         echo "tag=${TAG}" >> $GITHUB_OUTPUT

--- a/.github/actions/get-auto-release-tag/action.yml
+++ b/.github/actions/get-auto-release-tag/action.yml
@@ -12,6 +12,11 @@ inputs:
   token:
     description: "The GitHub token passed from the caller workflow"
     required: true
+  release_if:
+    description: "The condition to release the image"
+    required: false
+    default: "true"
+    type: string
 
 outputs:
   image_tags:
@@ -49,18 +54,18 @@ runs:
       id: exists
       with:
         image_name: ${{ github.repository }}
-        image_tag: ${{ steps.parse-package.outputs.version }}
+        image_tag: v${{ steps.parse-package.outputs.version }}
         token: ${{ inputs.token }}
 
     - name: Calculate tag
       id: calculate
       run: |
         IMAGE_TAGS="${{ steps.parse-git.outputs.tag }}"
-        if [[ "${{ steps.exists.outputs.exists }}" == "true" ]]; then
+        if [ "${{ steps.exists.outputs.exists }}" == "true" ] || [ "${{ inputs.release_if }}" != "true" ]; then
           CREATE_TAG=false
         else
           CREATE_TAG=true
-          GIT_TAG="${{ steps.parse-package.outputs.version }}"
+          GIT_TAG="v${{ steps.parse-package.outputs.version }}"
           IMAGE_TAGS="${IMAGE_TAGS},${GIT_TAG}"
         fi
         echo "Image tags: ${IMAGE_TAGS}"


### PR DESCRIPTION
## Description

After merging into main in DC, I realized that Docker tags with the version are created on the develop branch as well and without the `v` prefix.

This PR fixes the prefix and pulls the special condition for tag release into this action (which simplifies the usage as well).

Minor fix included: properly generate the docker tag when building on a feature branch, we don't use those yet outside of testing but it will be useful in the future and it's useful now when I do test.

## Review guidelines

<!-- Required: estimate how long a review should take -->
Estimated Time of Review: 2 minutes

<!-- Optional: provide more suggestions such as "Review by commit", "Read this documentation first", etc -->

<!-- Optional: define a task list that should be completed before merging
## Checklist before merging:
- [x] Task 1
- [ ] Task 2
-->

## Related issues
### Blocks:

DC PR