### PR TITLE
feat(gha): add new actions for buildx bake and suffixes

### DIFF
--- a/.github/actions/docker-build-multi/action.yml
+++ b/.github/actions/docker-build-multi/action.yml
@@ -43,7 +43,7 @@ runs:
     # as the variable doesn't exist when GitHub resolves it
     - name: Create symlink for actions from this repository
       run: |
-        ln -s ${{ github.action_path }}/../.. .gha-db
+        ln -s ${{ github.action_path }}/../.. .gha-dbm
       shell: bash
 
     - name: Set up QEMU
@@ -51,7 +51,7 @@ runs:
       with:
         platforms: ${{ inputs.platforms }}
 
-    - uses: ./.gha-db/actions/docker-build
+    - uses: ./.gha-dbm/actions/docker-build
       id: build-push
       with:
         image_name: ${{ inputs.image_name }}

--- a/.github/actions/docker-build/action.yml
+++ b/.github/actions/docker-build/action.yml
@@ -32,24 +32,34 @@ outputs:
 runs:
   using: composite
   steps:
+    # When using a composite action from another repo,
+    # there is no canonical way to call other composite actions from that same repo
+    # so we make a symlink to the repo's .github folder so that local `uses: ./` can work
+    # Note: using ${{ github.action_path }} in a `uses:` does not work
+    # as the variable doesn't exist when GitHub resolves it
+    - name: Create symlink for actions from this repository
+      run: |
+        ln -s ${{ github.action_path }}/../.. .gha-db
+      shell: bash
+
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2
       with:
         version: v0.10.4 # due to --provenance
 
+    - uses: ./.gha-db/actions/list-add-suffixes
+      id: calculate-images
+      with:
+        list: -t ${{ inputs.image_name }}
+        suffixes: ${{ inputs.image_tags }}
+        output_separator: " "
+
     - id: build-push
       name: Build and push image
       run: |
-        IMAGES=()
-        IMAGE=${{ inputs.image_name }}
-        IFS=',' read -ra TAGS <<< ${{ inputs.image_tags }}
-        for TAG in "${TAGS[@]}"
-        do
-          IMAGES+=(-t ${IMAGE}:${TAG})
-        done
         docker buildx build --file ${{ inputs.dockerfile_path }} \
           ${{ inputs.build_flags }} \
-          --push --provenance=false --sbom=false ${IMAGES[@]} \
+          --push --provenance=false --sbom=false ${{ steps.calculate-images.outputs.list }} \
           ${{ inputs.build_context_path }}
         SHA=$(docker buildx imagetools inspect ${IMAGE}:${TAG} | grep Digest)
         echo "sha=${SHA##*sha256:}" >> $GITHUB_OUTPUT

--- a/.github/actions/docker-build/action.yml
+++ b/.github/actions/docker-build/action.yml
@@ -52,6 +52,7 @@ runs:
       with:
         list: -t ${{ inputs.image_name }}
         suffixes: ${{ inputs.image_tags }}
+        glue_separator: ":"
         output_separator: " "
 
     - id: build-push

--- a/.github/actions/docker-tag-from-git/action.yml
+++ b/.github/actions/docker-tag-from-git/action.yml
@@ -17,14 +17,16 @@ runs:
         # <branch> if it's a branch (and replace / with -)
         GITHUB_REFER="${{ github.ref }}"
         BRANCH="${{ github.ref_name }}"
+        RUN="${{ github.run_number }}"
         if [[ "${BRANCH}" == "develop" ]]; then
-          TAG="develop-${{ github.run_number }}"
+          TAG="develop,develop-${RUN}"
         elif [[ "${BRANCH}" == "main" ]]; then
-          TAG=latest
+          TAG="latest,main-${RUN}"
         elif [[ "${GITHUB_REFER}" == "refs/tags/"* ]]; then
           TAG="${GITHUB_REFER#refs/tags/}"
         else
-          TAG="${BRANCH//\//-}"
+          BRANCH_SAFE="${BRANCH//\//-}"
+          TAG="${BRANCH_SAFE},${BRANCH_SAFE}-${RUN}"
         fi
         echo "Tag: ${TAG}"
         echo "tag=${TAG}" >> $GITHUB_OUTPUT

--- a/.github/actions/ghcr-bake/action.yaml
+++ b/.github/actions/ghcr-bake/action.yaml
@@ -69,6 +69,7 @@ runs:
           ${{ steps.calculate-tags.outputs.list }} \
           --file ${{ inputs.bake_file }} \
           --progress plain \
+          --provenance=false --sbom=false \
           ${opts} \
           ${{ inputs.bake_flags }}
       shell: bash

--- a/.github/actions/ghcr-bake/action.yaml
+++ b/.github/actions/ghcr-bake/action.yaml
@@ -35,6 +35,11 @@ runs:
       with:
         token: ${{ inputs.token }}
 
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+      with:
+        version: v0.10.4 # due to buildx-bake
+
     - name: build using Bake
       run: |
         docker buildx bake \

--- a/.github/actions/ghcr-bake/action.yaml
+++ b/.github/actions/ghcr-bake/action.yaml
@@ -9,7 +9,11 @@ inputs:
     description: "Any flags to be passed to docker buildx bake"
     required: false
     type: string
-  tags:
+  image_name:
+    description: 'The name of the image (for example "aica-technology/image-name")'
+    required: true
+    type: string
+  image_tags:
     description: 'The tags of the image (for example "latest,v1.0.0")'
     required: false
     default: latest
@@ -45,8 +49,8 @@ runs:
       with:
         # need extra escaping because of the meaning of * in bash,
         # quotes are more awkward due to being used elsewhere and stripped by yaml
-        list: --set \*.tags=
-        suffixes: ${{ inputs.tags }}
+        list: --set \*.tags=${{ inputs.image_name }}
+        suffixes: :${{ inputs.tags }}
         output_separator: " "
 
     - name: build using Bake

--- a/.github/actions/ghcr-bake/action.yaml
+++ b/.github/actions/ghcr-bake/action.yaml
@@ -1,0 +1,41 @@
+name: Build and Push (multi-arch) for GHCR using buildx bake
+
+inputs:
+  bake_file:
+    description: "Path to the main bake.*.hcl file"
+    required: true
+    type: string
+  bake_flags:
+    description: "Any flags to be passed to docker buildx bake"
+    required: false
+    type: string
+  token:
+    description: "The GitHub token passed from the caller workflow"
+    required: true
+
+runs:
+  using: composite
+  steps:
+    # When using a composite action from another repo,
+    # there is no canonical way to call other composite actions from that same repo
+    # so we make a symlink to the repo's .github folder so that local `uses: ./` can work
+    # Note: using ${{ github.action_path }} in a `uses:` does not work
+    # as the variable doesn't exist when GitHub resolves it
+    - name: Create symlink for actions from this repository
+      run: |
+        ln -s ${{ github.action_path }}/../.. .gha-gbk
+      shell: bash
+
+    - uses: ./.gha-gbk/actions/login-to-ghcr
+      with:
+        token: ${{ inputs.token }}
+
+    - name: build using Bake
+      run: |
+        docker buildx bake \
+          --push \
+          --set *.tags=${{ steps.merge-tags.outputs.list }} \
+          --file ${{ inputs.bake_file }} \
+          ${{ inputs.bake_flags }} \
+          --progress plain
+      shell: bash

--- a/.github/actions/ghcr-bake/action.yaml
+++ b/.github/actions/ghcr-bake/action.yaml
@@ -49,8 +49,9 @@ runs:
       with:
         # need extra escaping because of the meaning of * in bash,
         # quotes are more awkward due to being used elsewhere and stripped by yaml
-        list: '--set \*.tags=${{ inputs.image_name }}:'
+        list: --set \*.tags=${{ inputs.image_name }}
         suffixes: ${{ inputs.image_tags }}
+        glue_separator: ":"
         output_separator: " "
 
     - name: build using Bake

--- a/.github/actions/ghcr-bake/action.yaml
+++ b/.github/actions/ghcr-bake/action.yaml
@@ -43,7 +43,9 @@ runs:
     - uses: ./.gha-gbk/actions/list-add-suffixes
       id: calculate-tags
       with:
-        list: --set \\*.tags=
+        # need extra escaping because of the meaning of * in bash,
+        # quotes are more awkward due to being used elsewhere and stripped by yaml
+        list: --set \*.tags=
         suffixes: ${{ inputs.tags }}
         output_separator: " "
 

--- a/.github/actions/ghcr-bake/action.yaml
+++ b/.github/actions/ghcr-bake/action.yaml
@@ -10,7 +10,7 @@ inputs:
     required: false
     type: string
   tags:
-    description: "The tags of the image (for example "latest,v1.0.0")"
+    description: 'The tags of the image (for example "latest,v1.0.0")'
     required: false
     default: latest
     type: string

--- a/.github/actions/ghcr-bake/action.yaml
+++ b/.github/actions/ghcr-bake/action.yaml
@@ -43,7 +43,7 @@ runs:
     - uses: ./.gha-gbk/actions/list-add-suffixes
       id: calculate-tags
       with:
-        list: --set \'*.tags=\'
+        list: --set \\*.tags=
         suffixes: ${{ inputs.tags }}
         output_separator: " "
 

--- a/.github/actions/ghcr-bake/action.yaml
+++ b/.github/actions/ghcr-bake/action.yaml
@@ -43,7 +43,7 @@ runs:
     - uses: ./.gha-gbk/actions/list-add-suffixes
       id: calculate-tags
       with:
-        list: --set *.tags=
+        list: --set \\*.tags=
         suffixes: ${{ inputs.tags }}
         output_separator: " "
 

--- a/.github/actions/ghcr-bake/action.yaml
+++ b/.github/actions/ghcr-bake/action.yaml
@@ -43,7 +43,7 @@ runs:
     - uses: ./.gha-gbk/actions/list-add-suffixes
       id: calculate-tags
       with:
-        list: --set \\*.tags=
+        list: --set '*.tags='
         suffixes: ${{ inputs.tags }}
         output_separator: " "
 

--- a/.github/actions/ghcr-bake/action.yaml
+++ b/.github/actions/ghcr-bake/action.yaml
@@ -9,6 +9,11 @@ inputs:
     description: "Any flags to be passed to docker buildx bake"
     required: false
     type: string
+  tags:
+    description: "The tags of the image (for example "latest,v1.0.0")"
+    required: false
+    default: latest
+    type: string
   token:
     description: "The GitHub token passed from the caller workflow"
     required: true
@@ -34,7 +39,7 @@ runs:
       run: |
         docker buildx bake \
           --push \
-          --set *.tags=${{ steps.merge-tags.outputs.list }} \
+          --set *.tags=${{ inputs.tags }} \
           --file ${{ inputs.bake_file }} \
           ${{ inputs.bake_flags }} \
           --progress plain

--- a/.github/actions/ghcr-bake/action.yaml
+++ b/.github/actions/ghcr-bake/action.yaml
@@ -40,7 +40,7 @@ runs:
       with:
         version: v0.10.4 # due to buildx-bake
 
-    - uses: ./.gha-db/actions/list-add-suffixes
+    - uses: ./.gha-gbk/actions/list-add-suffixes
       id: calculate-tags
       with:
         list: --set *.tags=

--- a/.github/actions/ghcr-bake/action.yaml
+++ b/.github/actions/ghcr-bake/action.yaml
@@ -43,7 +43,7 @@ runs:
     - uses: ./.gha-gbk/actions/list-add-suffixes
       id: calculate-tags
       with:
-        list: --set '*.tags='
+        list: --set \'*.tags=\'
         suffixes: ${{ inputs.tags }}
         output_separator: " "
 
@@ -51,7 +51,7 @@ runs:
       run: |
         docker buildx bake \
           --push \
-          ${{ steps.calculate-tags.outputs.list }}
+          ${{ steps.calculate-tags.outputs.list }} \
           --file ${{ inputs.bake_file }} \
           ${{ inputs.bake_flags }} \
           --progress plain

--- a/.github/actions/ghcr-bake/action.yaml
+++ b/.github/actions/ghcr-bake/action.yaml
@@ -40,11 +40,18 @@ runs:
       with:
         version: v0.10.4 # due to buildx-bake
 
+    - uses: ./.gha-db/actions/list-add-suffixes
+      id: calculate-tags
+      with:
+        list: --set *.tags=
+        suffixes: ${{ inputs.tags }}
+        output_separator: " "
+
     - name: build using Bake
       run: |
         docker buildx bake \
           --push \
-          --set *.tags=${{ inputs.tags }} \
+          ${{ steps.calculate-tags.outputs.list }}
           --file ${{ inputs.bake_file }} \
           ${{ inputs.bake_flags }} \
           --progress plain

--- a/.github/actions/ghcr-bake/action.yaml
+++ b/.github/actions/ghcr-bake/action.yaml
@@ -49,8 +49,8 @@ runs:
       with:
         # need extra escaping because of the meaning of * in bash,
         # quotes are more awkward due to being used elsewhere and stripped by yaml
-        list: --set \*.tags=${{ inputs.image_name }}
-        suffixes: :${{ inputs.tags }}
+        list: '--set \*.tags=${{ inputs.image_name }}:'
+        suffixes: ${{ inputs.image_tags }}
         output_separator: " "
 
     - name: build using Bake

--- a/.github/actions/ghcr-manifest-merge/action.yml
+++ b/.github/actions/ghcr-manifest-merge/action.yml
@@ -9,6 +9,11 @@ inputs:
     description: 'The tags of the image (for example "latest,v1.0.0")'
     required: true
     type: string
+  arch_tag_prefix:
+    description: 'The prefix to add to the arch tag (for example "latest-")'
+    required: false
+    default: ""
+    type: string
   archs:
     description: 'The archs to merge as comma-separated list (for example "amd64,arm64")'
     required: true
@@ -55,9 +60,9 @@ runs:
     - uses: ./.gha-gmm/actions/list-add-suffixes
       id: calculate-images
       with:
-        list: ${{ steps.calculate-inputs.outputs.list }}
+        list: ${{ steps.ensure-image.outputs.image_name }}
         suffixes: ${{ inputs.archs }}
-        glue_separator: "-"
+        glue_separator: ":${{ inputs.arch_tag_prefix }}"
 
     - uses: Noelware/docker-manifest-action@0.3.1
       with:

--- a/.github/actions/ghcr-manifest-merge/action.yml
+++ b/.github/actions/ghcr-manifest-merge/action.yml
@@ -9,11 +9,6 @@ inputs:
     description: 'The tags of the image (for example "latest,v1.0.0")'
     required: true
     type: string
-  arch_tag_prefix:
-    description: 'The prefix to add to the arch tag (for example "latest-")'
-    required: false
-    default: ""
-    type: string
   archs:
     description: 'The archs to merge as comma-separated list (for example "amd64,arm64")'
     required: true
@@ -51,21 +46,23 @@ runs:
         image_name: ${{ inputs.image_name }}
 
     - uses: ./.gha-gmm/actions/list-add-suffixes
-      id: calculate-inputs
+      id: calculate-images
       with:
         list: ${{ steps.ensure-image.outputs.image_name }}
         suffixes: ${{ inputs.image_tags }}
         glue_separator: ":"
 
-    - uses: ./.gha-gmm/actions/list-add-suffixes
-      id: calculate-images
-      with:
-        list: ${{ steps.ensure-image.outputs.image_name }}
-        suffixes: ${{ inputs.archs }}
-        glue_separator: ":${{ inputs.arch_tag_prefix }}"
-
-    - uses: Noelware/docker-manifest-action@0.3.1
-      with:
-        inputs: ${{ steps.calculate-inputs.outputs.list }}
-        images: ${{ steps.calculate-images.outputs.list }}
-        push: true
+    - name: Create manifests
+      run: |
+        IFS=',' read -ra IMAGES <<< '${{ steps.calculate-images.outputs.list }}'
+        for IMAGE in "${IMAGES[@]}"; do
+          PARTS=()
+          IFS=',' read -ra ARCHS <<< '${{ inputs.archs }}'
+          for ARCH in "${ARCHS[@]}"; do
+            PARTS+=("${IMAGE}-${ARCH}")
+          done
+          echo "Creating manifest for ${IMAGE} with parts ${PARTS[@]}"
+          docker manifest create "${IMAGE}" ${PARTS[@]}
+          docker manifest push "${IMAGE}"
+        done
+      shell: bash

--- a/.github/actions/ghcr-manifest-merge/action.yml
+++ b/.github/actions/ghcr-manifest-merge/action.yml
@@ -45,34 +45,20 @@ runs:
       with:
         image_name: ${{ inputs.image_name }}
 
-    - name: Calculate intermediate image names
-      id: calculate-intermediate
-      run: |
-        IMAGE="${{ steps.ensure-image.outputs.image_name }}"
+    - uses: ./.gha-gmm/actions/list-add-suffixes
+      id: calculate-inputs
+      with:
+        list: ${{ steps.ensure-image.outputs.image_name }}
+        suffixes: ${{ inputs.image_tags }}
 
-        INPUTS=()
-        IMAGES=()
-        IFS=',' read -ra TAGS <<< ${{ inputs.image_tags }}
-        for TAG in "${TAGS[@]}"
-        do
-          INPUTS+=("${IMAGE}:${TAG}")
-          IFS=',' read -ra ARCHS <<< ${{ inputs.archs }}
-          for ARCH in "${ARCHS[@]}"
-          do
-            IMAGES+=("${IMAGE}:${TAG}-${ARCH}")
-          done
-        done
-        JOINED_INPUTS="$(IFS=, ; echo "${INPUTS[*]}")"
-        JOINED_IMAGES="$(IFS=, ; echo "${IMAGES[*]}")"
-
-        echo "Inputs: ${JOINED_INPUTS}"
-        echo "Images: ${JOINED_IMAGES}"
-        echo "inputs=${JOINED_INPUTS}" >> $GITHUB_OUTPUT
-        echo "images=${JOINED_IMAGES}" >> $GITHUB_OUTPUT
-      shell: bash
+    - uses: ./.gha-gmm/actions/list-add-suffixes
+      id: calculate-images
+      with:
+        list: ${{ steps.calculate-inputs.outputs.list }}
+        suffixes: ${{ inputs.archs }}
 
     - uses: Noelware/docker-manifest-action@0.3.1
       with:
-        inputs: ${{ steps.calculate-intermediate.outputs.inputs }}
-        images: ${{ steps.calculate-intermediate.outputs.images }}
+        inputs: ${{ steps.calculate-inputs.outputs.list }}
+        images: ${{ steps.calculate-images.outputs.list }}
         push: true

--- a/.github/actions/ghcr-manifest-merge/action.yml
+++ b/.github/actions/ghcr-manifest-merge/action.yml
@@ -50,12 +50,14 @@ runs:
       with:
         list: ${{ steps.ensure-image.outputs.image_name }}
         suffixes: ${{ inputs.image_tags }}
+        glue_separator: ":"
 
     - uses: ./.gha-gmm/actions/list-add-suffixes
       id: calculate-images
       with:
         list: ${{ steps.calculate-inputs.outputs.list }}
         suffixes: ${{ inputs.archs }}
+        glue_separator: "-"
 
     - uses: Noelware/docker-manifest-action@0.3.1
       with:

--- a/.github/actions/ghcr-push/action.yaml
+++ b/.github/actions/ghcr-push/action.yaml
@@ -1,14 +1,6 @@
-name: Build and Push (multi-arch) for GHCR using buildx bake
+name: Push images to GHCR
 
 inputs:
-  bake_file:
-    description: "Path to the main bake.*.hcl file"
-    required: true
-    type: string
-  bake_flags:
-    description: "Any flags to be passed to docker buildx bake"
-    required: false
-    type: string
   image_name:
     description: 'The name of the image (for example "aica-technology/image-name")'
     required: true
@@ -18,11 +10,6 @@ inputs:
     required: false
     default: latest
     type: string
-  push:
-    description: "Whether to push the image to the registry"
-    required: false
-    default: true
-    type: boolean
   token:
     description: "The GitHub token passed from the caller workflow"
     required: true
@@ -37,38 +24,24 @@ runs:
     # as the variable doesn't exist when GitHub resolves it
     - name: Create symlink for actions from this repository
       run: |
-        ln -s ${{ github.action_path }}/../.. .gha-gbk
+        ln -s ${{ github.action_path }}/../.. .gha-gp
       shell: bash
 
-    - uses: ./.gha-gbk/actions/login-to-ghcr
+    - uses: ./.gha-gp/actions/login-to-ghcr
       with:
         token: ${{ inputs.token }}
-
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v2
-      with:
-        version: v0.10.4 # due to buildx-bake
 
     - uses: ./.gha-gbk/actions/list-add-suffixes
       id: calculate-tags
       with:
         # need extra escaping because of the meaning of * in bash,
         # quotes are more awkward due to being used elsewhere and stripped by yaml
-        list: --set \*.tags=${{ inputs.image_name }}
+        list: ${{ inputs.image_name }}
         suffixes: ${{ inputs.image_tags }}
         glue_separator: ":"
         output_separator: " "
 
-    - name: build using Bake
+    - name: Push to GHCR
       run: |
-        opts=""
-        if [[ "${{ inputs.push }}" == "true" ]]; then
-          opts="--push"
-        fi
-        docker buildx bake \
-          ${{ steps.calculate-tags.outputs.list }} \
-          --file ${{ inputs.bake_file }} \
-          --progress plain \
-          ${opts} \
-          ${{ inputs.bake_flags }}
+        docker push ${{ steps.calculate-tags.outputs.list }}
       shell: bash

--- a/.github/actions/ghcr-push/action.yaml
+++ b/.github/actions/ghcr-push/action.yaml
@@ -34,8 +34,6 @@ runs:
     - uses: ./.gha-gbk/actions/list-add-suffixes
       id: calculate-tags
       with:
-        # need extra escaping because of the meaning of * in bash,
-        # quotes are more awkward due to being used elsewhere and stripped by yaml
         list: ${{ inputs.image_name }}
         suffixes: ${{ inputs.image_tags }}
         glue_separator: ":"

--- a/.github/actions/ghcr-push/action.yaml
+++ b/.github/actions/ghcr-push/action.yaml
@@ -43,5 +43,7 @@ runs:
 
     - name: Push to GHCR
       run: |
-        docker push ${{ steps.calculate-tags.outputs.list }}
+        for TAG in ${{ steps.calculate-tags.outputs.list }}; do
+          docker push "${TAG}"
+        done
       shell: bash

--- a/.github/actions/ghcr-push/action.yaml
+++ b/.github/actions/ghcr-push/action.yaml
@@ -39,11 +39,11 @@ runs:
         list: ${{ inputs.image_name }}
         suffixes: ${{ inputs.image_tags }}
         glue_separator: ":"
-        output_separator: " "
 
     - name: Push to GHCR
       run: |
-        for TAG in ${{ steps.calculate-tags.outputs.list }}; do
+        IFS="," read -r -a TAGS <<< "${{ steps.calculate-tags.outputs.result }}"
+        for TAG in "${TAGS[@]}"; do
           docker push "${TAG}"
         done
       shell: bash

--- a/.github/actions/list-add-suffixes/action.yaml
+++ b/.github/actions/list-add-suffixes/action.yaml
@@ -19,6 +19,11 @@ inputs:
     required: false
     type: string
     default: ","
+  glue_separator:
+    description: "The separator used to join the `list` elements to the `suffixes`"
+    required: false
+    type: string
+    default: ""
   output_separator:
     description: "The separator used to join the output list"
     required: false
@@ -42,7 +47,7 @@ runs:
           IFS="${{ inputs.suffix_separator }}" read -ra SUFFIXES <<< '${{ inputs.suffixes }}'
           for SUFFIX in "${SUFFIXES[@]}"
           do
-            ALIST+=("${ITEM}${SUFFIX}")
+            ALIST+=("${ITEM}${{ inputs.glue_separator }}${SUFFIX}")
           done
         done
         JOINED_LIST="$(IFS="${{ inputs.output_separator }}" ; echo "${ALIST[*]}")"

--- a/.github/actions/list-add-suffixes/action.yaml
+++ b/.github/actions/list-add-suffixes/action.yaml
@@ -36,10 +36,10 @@ runs:
       id: merge
       run: |
         ALIST=()
-        IFS="${{ inputs.list_separator }}" read -ra ITEMS <<< ${{ inputs.list }}
+        IFS="${{ inputs.list_separator }}" read -ra ITEMS <<< '${{ inputs.list }}'
         for ITEM in "${ITEMS[@]}"
         do
-          IFS="${{ inputs.suffix_separator }}" read -ra SUFFIXES <<< ${{ inputs.suffixes }}
+          IFS="${{ inputs.suffix_separator }}" read -ra SUFFIXES <<< '${{ inputs.suffixes }}'
           for SUFFIX in "${SUFFIXES[@]}"
           do
             ALIST+=("${ITEM}${SUFFIX}")

--- a/.github/actions/list-add-suffixes/action.yaml
+++ b/.github/actions/list-add-suffixes/action.yaml
@@ -1,0 +1,52 @@
+name: Add suffixes to each string in a list
+
+inputs:
+  list:
+    description: "A list of string separated by `separator`"
+    required: true
+    type: string
+  list_separator:
+    description: "The separator used to split the `list`"
+    required: false
+    type: string
+    default: ","
+  suffixes:
+    description: "The list of suffixes to add to each string in `list`, separated by `suffix_separator`"
+    required: true
+    type: string
+  suffix_separator:
+    description: "The separator used to split the `suffixes`"
+    required: false
+    type: string
+    default: ","
+  output_separator:
+    description: "The separator used to join the output list"
+    required: false
+    type: string
+    default: ","
+outputs:
+  list:
+    description: "The list with the suffixes added"
+    value: ${{ steps.merge.outputs.list }}
+
+steps:
+  - name: Merge suffix with list
+    id: merge
+    run: |
+      ALIST=()
+      IFS="${{ inputs.list_separator }}" read -ra ITEMS <<< ${{ inputs.list }}
+      for ITEM in "${ITEMS[@]}"
+      do
+        IFS="${{ inputs.suffix_separator }}" read -ra SUFFIXES <<< ${{ inputs.suffixes }}
+        for SUFFIX in "${SUFFIXES[@]}"
+        do
+          ALIST+=("${ITEM}${SUFFIX}")
+        done
+      done
+      JOINED_LIST="$(IFS="${{ inputs.output_separator }}" ; echo "${ALIST[*]}")"
+
+      echo "Suffixes: ${{ inputs.suffixes }}"
+      echo "In : ${{ inputs.list }}"
+      echo "Out: ${JOINED_LIST}"
+      echo "list=${JOINED_LIST}" >> $GITHUB_OUTPUT
+    shell: bash

--- a/.github/actions/list-add-suffixes/action.yaml
+++ b/.github/actions/list-add-suffixes/action.yaml
@@ -29,24 +29,26 @@ outputs:
     description: "The list with the suffixes added"
     value: ${{ steps.merge.outputs.list }}
 
-steps:
-  - name: Merge suffix with list
-    id: merge
-    run: |
-      ALIST=()
-      IFS="${{ inputs.list_separator }}" read -ra ITEMS <<< ${{ inputs.list }}
-      for ITEM in "${ITEMS[@]}"
-      do
-        IFS="${{ inputs.suffix_separator }}" read -ra SUFFIXES <<< ${{ inputs.suffixes }}
-        for SUFFIX in "${SUFFIXES[@]}"
+runs:
+  using: composite
+  steps:
+    - name: Merge suffix with list
+      id: merge
+      run: |
+        ALIST=()
+        IFS="${{ inputs.list_separator }}" read -ra ITEMS <<< ${{ inputs.list }}
+        for ITEM in "${ITEMS[@]}"
         do
-          ALIST+=("${ITEM}${SUFFIX}")
+          IFS="${{ inputs.suffix_separator }}" read -ra SUFFIXES <<< ${{ inputs.suffixes }}
+          for SUFFIX in "${SUFFIXES[@]}"
+          do
+            ALIST+=("${ITEM}${SUFFIX}")
+          done
         done
-      done
-      JOINED_LIST="$(IFS="${{ inputs.output_separator }}" ; echo "${ALIST[*]}")"
+        JOINED_LIST="$(IFS="${{ inputs.output_separator }}" ; echo "${ALIST[*]}")"
 
-      echo "Suffixes: ${{ inputs.suffixes }}"
-      echo "In : ${{ inputs.list }}"
-      echo "Out: ${JOINED_LIST}"
-      echo "list=${JOINED_LIST}" >> $GITHUB_OUTPUT
-    shell: bash
+        echo "Suffixes: ${{ inputs.suffixes }}"
+        echo "In : ${{ inputs.list }}"
+        echo "Out: ${JOINED_LIST}"
+        echo "list=${JOINED_LIST}" >> $GITHUB_OUTPUT
+      shell: bash


### PR DESCRIPTION
## Description

Support new HC PR and closes #16 

 * Introduces an helper action to calculate all the permutations of two lists and use it everywhere applicable
 * Fix a small typo in symlink for one of the action
 * Add more git-based docker tags (`develop-X` on `develop` #16 and `<branch>-X` on `<branch>`)
 * Add an action to run `docker buildx bake` with GHCR
 * Add an action to push docker images on GHCR


## Review guidelines

<!-- Required: estimate how long a review should take -->
Estimated Time of Review: 5 minutes

<!-- Optional: provide more suggestions such as "Review by commit", "Read this documentation first", etc -->

<!-- Optional: define a task list that should be completed before merging
## Checklist before merging:
- [x] Task 1
- [ ] Task 2
-->

## Related issues
### Blocks:

HC CI PR