### PR TITLE
ci: fix choice of path for check version toml

### DIFF
--- a/.github/actions/check-version-toml/action.yml
+++ b/.github/actions/check-version-toml/action.yml
@@ -48,14 +48,12 @@ runs:
 
     - name: Get package file from previous commit
       run: |
-        git show HEAD^:${{ inputs.package_path }}/aica-package.toml > /tmp/aica-package.toml
+        git show HEAD^:${{ inputs.package_path }}/aica-package.toml > aica-package.toml
       shell: bash
 
     - name: Parse version of previous commit
       id: parse-base-version
       uses: ./.chk-vrs-toml/actions/parse-package-toml
-      with:
-        directory: /tmp
 
     - name: Parse version of current commit
       id: parse-new-version


### PR DESCRIPTION
<!-- Pull Request guidelines:
1. Give the PR a relevant and descriptive title, using one of the supported commit types:
   [ build, ci, chore, docs, feat, fix, perf, refactor, release, revert, style, test ]
2. Link the PR to the parent issue, which should already describe and motivate the PR
3. Explain how the PR addresses the parent issue
4. Add any supporting resources (screenshots, test results, etc)
5. Help the reviewer by suggesting the method and estimated time to review
6. If applicable, make a checklist of tasks that should be completed before merging
7. If applicable, mention related issues (blocked by / blocks)
8. Post creation actions: tag reviewers and link the PR to its parent issue under the Development section
-->

## Description

<!-- Required: link the parent issue -->

<!-- Required: explain how the PR addresses the parent issue -->
This PR fixes the check-version-toml (its tested now). The problem was that the `mikefarah/yq` action is run in docker and the `/tmp` directory is not mounted, so we need to be more careful where to put the temporary `aica-package.toml`.

<!-- Optional: add additional resources (links, screenshots, test results, etc)
## Supporting information
-->

## Review guidelines

<!-- Required: estimate how long a review should take -->
Estimated Time of Review: 2 minutes

<!-- Optional: provide more suggestions such as "Review by commit", "Read this documentation first", etc -->

## Checklist before merging:

- [ ] Confirm that the relevant changelog(s) are up-to-date in case of any user-facing changes

<!-- Optional: define further tasks that should be completed before merging
- [x] Task 1
- [ ] Task 2
-->

<!-- Optional: link related issues
## Related issues
### Blocked by:
- #0

### Blocks:
- #0
-->