### PR TITLE
style: AlignAfterOpenBracket BlockIndent

### DIFF
--- a/guidelines/.clang-format
+++ b/guidelines/.clang-format
@@ -1,7 +1,7 @@
 # Generated from CLion C/C++ Code Style settings
 BasedOnStyle: LLVM
 AccessModifierOffset: -2
-AlignAfterOpenBracket: AlwaysBreak
+AlignAfterOpenBracket: BlockIndent
 AlignConsecutiveAssignments: None
 AlignOperands: DontAlign
 AllowAllArgumentsOnNextLine: true


### PR DESCRIPTION
<!-- Pull Request guidelines:
1. Give the PR a relevant and descriptive title, using one of the supported commit types:
   [ build, ci, chore, docs, feat, fix, perf, refactor, release, revert, style, test ]
2. Link the PR to the parent issue, which should already describe and motivate the PR
3. Explain how the PR addresses the parent issue
4. Add any supporting resources (screenshots, test results, etc)
5. Help the reviewer by suggesting the method and estimated time to review
6. If applicable, make a checklist of tasks that should be completed before merging
7. If applicable, mention related issues (blocked by / blocks)
8. Post creation actions: tag reviewers and link the PR to its parent issue under the Development section
-->

## Description

<!-- Required: link the parent issue -->

In most of our existing codebases (control libraries, modulo, etc) we have long functions formatted as:

```c++
  void add_parameter(
      const std::shared_ptr<state_representation::ParameterInterface>& parameter, const std::string& description,
      bool read_only = false
  );
```
(_[source](https://github.com/aica-technology/modulo/blob/b63153783506406a2f6dda23d3c9d5a3cb6cba4f/source/modulo_components/include/modulo_components/ComponentInterface.hpp#L93-L96)_)

However, the clang format file rule for this is currently `AlwaysBreak`, so it would actually format such a function as:

```c++
  void add_parameter(
      const std::shared_ptr<state_representation::ParameterInterface>& parameter, const std::string& description,
      bool read_only = false);
```

I am proposing this change to make the clang format file more consistent with our established code style.

## Supporting information

https://clang.llvm.org/docs/ClangFormatStyleOptions.html#alignafteropenbracket

## Review guidelines

<!-- Required: estimate how long a review should take -->
Estimated Time of Review: 1 minute

<!-- Optional: provide more suggestions such as "Review by commit", "Read this documentation first", etc -->

## Checklist before merging:

- [ ] Confirm that the relevant changelog(s) are up-to-date in case of any user-facing changes

<!-- Optional: define further tasks that should be completed before merging
- [x] Task 1
- [ ] Task 2
-->

<!-- Optional: link related issues
## Related issues
### Blocked by:
- #0

### Blocks:
- #0
-->