### PR TITLE
fix(parse-package-toml): fix the action for new version of package-builder

### DIFF
--- a/.github/actions/parse-package-toml/action.yml
+++ b/.github/actions/parse-package-toml/action.yml
@@ -37,8 +37,8 @@ runs:
       id: metadata
       run: |
         INPUT="${{ inputs.directory }}/aica-package.toml"
-        NAME=$(yq '.metadata.name' $INPUT)
-        ROS_NAME=$(yq '.metadata.ros-name' $INPUT)
+        NAME=$(yq '.metadata.collection.name' $INPUT)
+        ROS_NAME=$(yq '.metadata.collection.ros-name' $INPUT)
         VERSION=$(yq '.metadata.version' $INPUT)
         echo "Name: $NAME"
         echo "Version: $VERSION"


### PR DESCRIPTION
<!-- Pull Request guidelines:
1. Give the PR a relevant and descriptive title, using one of the supported commit types:
   [ build, ci, chore, docs, feat, fix, perf, refactor, release, revert, style, test ]
2. Link the PR to the parent issue, which should already describe and motivate the PR
3. Explain how the PR addresses the parent issue
4. Add any supporting resources (screenshots, test results, etc)
5. Help the reviewer by suggesting the method and estimated time to review
6. If applicable, make a checklist of tasks that should be completed before merging
7. If applicable, mention related issues (blocked by / blocks)
8. Post creation actions: tag reviewers and link the PR to its parent issue under the Development section
-->

## Description

Raised by @domire8 

This PR adapts the `parse-package-toml` to the new version of `package-builder` (v1 and later).

Main question: what version should we release this with? As it is a breaking change, should we go to `v1.0.0`? The issue is that all actions use the same version, so not sure if semver actually make sense?

<!-- Optional: add additional resources (links, screenshots, test results, etc)
## Supporting information
-->

## Review guidelines

<!-- Required: estimate how long a review should take -->
Estimated Time of Review: 3 minutes

<!-- Optional: provide more suggestions such as "Review by commit", "Read this documentation first", etc -->

<!-- Optional: define further tasks that should be completed before merging
- [x] Task 1
- [ ] Task 2
-->

<!-- Optional: link related issues
## Related issues
### Blocked by:
- #0

### Blocks:
- #0
-->